### PR TITLE
Add (very open) CORS headers

### DIFF
--- a/dcmrsbroker-core/src/main/java/org/rsna/isn/dcmrsbroker/core/spark/Router.java
+++ b/dcmrsbroker-core/src/main/java/org/rsna/isn/dcmrsbroker/core/spark/Router.java
@@ -60,6 +60,20 @@ public class Router implements SparkApplication
 		get(wadoBase + "/studies/:studyUid", new WadoRoute(Level.STUDY));
 		get(wadoBase + "/studies/:studyUid/series/:seriesUid", new WadoRoute(Level.SERIES));
 		get(wadoBase + "/studies/:studyUid/series/:seriesUid/instances/:instanceUid", new WadoRoute(Level.IMAGE));
+
+        options("/*", (request, response) -> {
+            String accessControlRequestHeaders = request.headers("Access-Control-Request-Headers");
+            if (accessControlRequestHeaders != null)
+                response.header("Access-Control-Allow-Headers", accessControlRequestHeaders);
+
+            String accessControlRequestMethod = request.headers("Access-Control-Request-Method");
+            if (accessControlRequestMethod != null)
+                response.header("Access-Control-Allow-Methods", accessControlRequestMethod);
+
+            return "OK";
+        });
+
+        before((request, response) -> response.header("Access-Control-Allow-Origin", "*"));
 	}
 
 	@Override


### PR DESCRIPTION
See the [pull request](https://github.com/RSNA/s4s-fhir-broker/pull/7) in the S4S FHIR broker repository.

This adds very permissive CORS headers to responses so that the data may be fetched from the browser.